### PR TITLE
Update bitvalues in hx711.py and updated calibration.py

### DIFF
--- a/example_python3.py
+++ b/example_python3.py
@@ -34,6 +34,13 @@ import time
 import sys
 from hx711 import HX711
 
+# Force Python 3 ###########################################################
+
+if sys.version_info[0] != '3':
+    raise Exception("Python 3 is required.")
+
+############################################################################
+
 
 hx = HX711(5, 6)
 

--- a/hx711.py
+++ b/hx711.py
@@ -38,17 +38,6 @@ class HX711:
         self.OFFSET = 0
         self.SCALE = 1
 
-        try:
-            if gain is 128:
-                self.GAIN = 1
-            elif gain is 64:
-                self.GAIN = 3
-            elif gain is 32:
-                self.GAIN = 2
-        except:
-            # Sets default GAIN
-            self.GAIN = 1
-
         # Setup the gpio pin numbering system
         GPIO.setmode(GPIO.BCM)
 
@@ -64,6 +53,22 @@ class HX711:
 
         # Power up the chip
         self.power_up()
+        self.set_gain(gain)
+
+    def set_gain(self, gain=128):
+
+        try:
+            if gain is 128:
+                self.GAIN = 1
+            elif gain is 64:
+                self.GAIN = 3
+            elif gain is 32:
+                self.GAIN = 2
+        except:
+            self.GAIN = 1  # Sets default GAIN
+
+        GPIO.output(self.PD_SCK, False)
+        self.read()
 
     def set_scale(self, scale):
         """
@@ -111,8 +116,6 @@ class HX711:
         # Lastly, behaviour matches while applying pressure
         # Please see page 8 of the PDF document
 
-        GPIO.output(self.PD_SCK, True)
-        GPIO.output(self.PD_SCK, False)
         count = 0
 
         for i in range(24):
@@ -125,6 +128,11 @@ class HX711:
         GPIO.output(self.PD_SCK, True)
         count = count ^ 0x800000
         GPIO.output(self.PD_SCK, False)
+
+        # set channel and gain factor for next reading
+        for i in range(self.GAIN):
+            GPIO.output(self.PD_SCK, True)
+            GPIO.output(self.PD_SCK, False)
 
         return count
 

--- a/hx711.py
+++ b/hx711.py
@@ -59,13 +59,13 @@ class HX711:
 
         try:
             if gain is 128:
-                self.GAIN = 1
-            elif gain is 64:
                 self.GAIN = 3
-            elif gain is 32:
+            elif gain is 64:
                 self.GAIN = 2
+            elif gain is 32:
+                self.GAIN = 1
         except:
-            self.GAIN = 1  # Sets default GAIN
+            self.GAIN = 3  # Sets default GAIN at 128
 
         GPIO.output(self.PD_SCK, False)
         self.read()


### PR DESCRIPTION
They seemed a bit arbitrary. Now the more gain you have the more bits it gives which makes sense in my head seeing as this is an amplifier. The good news is that this resulted in a weight in grams that's within the tolerance of my scale (50 kg scale measuring an item that weighs 1876g at values between 1700 and 2000 is good enough since it's around1.5% and this is a cheap part from China)

I believe that if your system has a high total weight, like mine at 50 kg you need a high gain, and vice versa if your system has lower total weight (like for example 200g), you'd want lower gain. Script calibration.py was updated in separate pull request.